### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   # Trigger the workflow on push events to the master branch


### PR DESCRIPTION
Potential fix for [https://github.com/Hanocybous/gantt-chart-visualizer/security/code-scanning/1](https://github.com/Hanocybous/gantt-chart-visualizer/security/code-scanning/1)

To fix the problem, add an explicit `permissions` key to set the minimal required GITHUB_TOKEN permissions. Since this is a standard Maven build workflow, and there is no step pushing to the repo, the minimal needed permission is likely `contents: read`. To guarantee that _all_ jobs (or, in this case, the single `build` job) receive minimal privilege, add the block at the root of the workflow (after `name:` and before `on:`). This will make it the default for all jobs, unless jobs have a more specific override. No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
